### PR TITLE
Configure flake8 and bandit hooks with pyproject

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
 
   # python import sorting
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--profile", "black", "--filter-files"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,20 +50,16 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        args:
-          [
-            "--extend-ignore",
-            "E203,E402,E501,F401,F841",
-            "--exclude",
-            "logs/*,data/*",
-          ]
+        entry: pflake8
+        additional_dependencies: ["pyproject-flake8"]
 
   # python security linter
   - repo: https://github.com/PyCQA/bandit
     rev: "1.7.1"
     hooks:
       - id: bandit
-        args: ["-s", "B101"]
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
 
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,15 @@ exclude_lines = [
     "raise NotImplementedError()",
     "if __name__ == .__main__.:",
 ]
+
+[tool.flake8]
+extend-ignore = ["E203", "E402", "E501", "F401", "F841"]
+exclude = ["logs/*","data/*"]
+per-file-ignores = [
+    '__init__.py:F401',
+]
+max-line-length = 99
+count = true
+
+[tool.bandit]
+skips = ["B101", "B311"]


### PR DESCRIPTION
With my auto-linters I ended up configuring flake8 in `pyproject.toml` anyway. This PR centralizes configs of linters to pyproject.
